### PR TITLE
chore: add dependabot configuration for weekly npm updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/multi-stock-sync"
+    schedule:
+      interval: "weekly"

--- a/multi-stock-sync/src/views/Sync/Views/Reportes/Router/RouterReportes.tsx
+++ b/multi-stock-sync/src/views/Sync/Views/Reportes/Router/RouterReportes.tsx
@@ -21,7 +21,7 @@ function RouterReportes() {
 
     return (
         <Routes>
-           <Route path="/*" element={<Navigate to="/sync/reportes/home" />} />  
+            <Route path="/*" element={<Navigate to="/sync/reportes/home" />} />  
             <Route path="home" element={<HomeReportes/>} />
             <Route path="filtrar-datos/:client_id" element={<FiltrarDatos />} />
             <Route path="exportar-datos/:client_id" element={<ExportarDatos />} />


### PR DESCRIPTION
This pull request includes a new configuration file `.github/dependabot.yml` to automate dependency updates for the `multi-stock-sync` project.

* [`.github/dependabot.yml`](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R1-R6): Added configuration to enable Dependabot for the `npm` package ecosystem with a weekly update schedule.